### PR TITLE
Harden Path to PRISM Binary

### DIFF
--- a/core/abstraction.py
+++ b/core/abstraction.py
@@ -472,7 +472,8 @@ class Abstraction(object):
         model_file      = '"'+self.mdp.prism_file+'"'
 
         # Explicit model
-        command = prism_folder + "bin/prism -javamaxmem " + \
+        prism_folder = prism_folder.replace("\n", "").replace("\r", "")
+        command = prism_folder + "/bin/prism -javamaxmem " + \
                   str(self.args.prism_java_memory) + "g -importmodel " + model_file + " -pf '" + \
                   spec + "' " + options
         


### PR DESCRIPTION
This removes newlines in the prism_folder variable and adds an additional directory separator in case the user has not terminated the path with one.